### PR TITLE
Set the pkg-config command as variable during make

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -16,8 +16,10 @@ endif
 endif
 
 CC ?= gcc
-LIBS = $(shell pkg-config --libs gtk+-2.0 gdk-pixbuf-2.0 gdk-pixbuf-xlib-2.0 x11) 
-INCS = $(shell pkg-config --cflags gtk+-2.0 gdk-pixbuf-2.0 gdk-pixbuf-xlib-2.0 x11)
+PKG_CONFIG ?= pkg-config
+
+LIBS = $(shell $(PKG_CONFIG) --libs gtk+-2.0 gdk-pixbuf-2.0 gdk-pixbuf-xlib-2.0 x11)
+INCS = $(shell $(PKG_CONFIG) --cflags gtk+-2.0 gdk-pixbuf-2.0 gdk-pixbuf-xlib-2.0 x11)
 CFLAGS ?= -O2 -Wall
 ifneq (,$(DEVEL))
 CFLAGS ?= -g -Wall 


### PR DESCRIPTION
Allows the location of the pkg-config command to be specified during
make using the PKG_CONFIG parameter.