### PR TITLE
Don't link against gdk-pixbuf-xlib-2.0 and remove unused include

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -18,8 +18,8 @@ endif
 CC ?= gcc
 PKG_CONFIG ?= pkg-config
 
-LIBS = $(shell $(PKG_CONFIG) --libs gtk+-2.0 gdk-pixbuf-2.0 gdk-pixbuf-xlib-2.0 x11)
-INCS = $(shell $(PKG_CONFIG) --cflags gtk+-2.0 gdk-pixbuf-2.0 gdk-pixbuf-xlib-2.0 x11)
+LIBS = $(shell $(PKG_CONFIG) --libs gtk+-2.0 gdk-pixbuf-2.0 x11)
+INCS = $(shell $(PKG_CONFIG) --cflags gtk+-2.0 gdk-pixbuf-2.0 x11)
 CFLAGS ?= -O2 -Wall
 ifneq (,$(DEVEL))
 CFLAGS ?= -g -Wall 

--- a/main.c
+++ b/main.c
@@ -2,7 +2,6 @@
 #include <unistd.h>
 #include <string.h>
 
-#include <X11/Xmu/WinUtil.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
 
 #include "panel.h"


### PR DESCRIPTION
Linking against gdk-pixbuf-xlib-2.0 isn't needed.
