### PR TITLE
add CPPFLAGS to compilation rules.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -26,10 +26,10 @@ CFLAGS ?= -g -Wall
 endif
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(INCS) -c $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(INCS) -c $<
 
 %.dep: %.c
-	$(CC) $(CFLAGS) $(INCS) -MM $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(INCS) -MM $< -o $@
 
 .PHONY: all clean distclean install uninstall
 


### PR DESCRIPTION
This is needed for Debian hardening flags, but shouldn't hurt in general.
Created by David Bremner <bremner@debian.org>.