### PR TITLE
feature: Added feature to define offsets from two edges simultaneously.

### DIFF
--- a/man/trayer.1
+++ b/man/trayer.1
@@ -2,14 +2,14 @@
 .SH NAME
   trayer-srg - a lightweight GTK2-based systray for UNIX desktop
 .SH SYNOPSYS
-.B trayer 
+.B trayer
 .B "[
 .I OPTIONS
 .B "]
 .SH DESCRIPTION
 trayer is small program designed to provide systray functionality present in GNOME/KDE desktop enviroments for window managers which doesn't support that function. It's similar to other applications such as 'peksystray' and 'docker'.
-   
-trayer code was extracted from fbpanel application, you can find more about it on it's homepage: 
+
+trayer code was extracted from fbpanel application, you can find more about it on it's homepage:
 .IB http://fbpanel.sourceforge.net/
 
 You can find new versions of trayer and support on FVWM-Crystal project homepage:
@@ -20,27 +20,27 @@ It contains all changes from above versions as far as known.
 Code of trayer-srg can be found on github:
 .IB http://github.com/sargon/trayer-srg
 .SH OPTIONS
-.TP 
-.BR \-h 
-prints help message and exits 
-.TP 
+.TP
+.BR \-h
+prints help message and exits
+.TP
 .BR \-v
 prints version and exits
 .TP
-.BR \--edge " EDGE" 
-Use 
+.BR \--edge " EDGE"
+Use
 .I EDGE
 for orientation. Possible values for
 .I EDGE
-are 
-.BR left, 
+are
+.BR left,
 .BR right,
 .BR top,
 .BR bottom
-or 
+or
 .BR none.
-The default value is 
-.BR bottom. 
+The default value is
+.BR bottom.
 .TP
 .BR \--align " ALIGNMENT"
 Orientation of docked icons inside the trayer panel. Possible values are
@@ -49,32 +49,33 @@ Orientation of docked icons inside the trayer panel. Possible values are
 .BR right,
 or
 .BR none.
-The default value is 
+The default value is
 .BR center.
 .TP
 .BR \--margin " NUM"
-Length of margin in pixels. The default value is 
+Length of margin in pixels. The default value is
 .BR 0.
 .TP
-.BR \--distance " NUM"
-Space between trayer's window and screen edge.
+.BR \--distance " NUM[,NUM"]
+Space between trayer's window and screen edge. If only one value for two edges
+is given, the same value is applied to both edges.
 When set to 0 the option has no effect.
 The default value is
-.BR 0.
+.BR 0,0.
 .TP
-.BR \--distancefrom " EDGE"
-Specifies which edge to calculate distance from, see 
+.BR \--distancefrom " EDGE[,EDGE"]
+Specifies which edges to calculate distance from, see
 .BR --edge.
-The default value is 
-.BR top.
- When 
-.BR --distance 
+The default value is
+.BR top,none.
+ When
+.BR --distance
 is 0 then this option has no effect.
 .TP
 .BR \--widthtype " TYPE"
 Determine how width is calculated. Possible values for
 .I TYPE
-are 
+are
 .BR pixel,
 .BR percent,
 .BR request
@@ -84,15 +85,15 @@ The default value is
 .BR percent.
 .TP
 .BR \--width " NUM"
-Width of a panel. When 
-.BR --widthtype=request 
-this option has no effect. The default value is 
+Width of a panel. When
+.BR --widthtype=request
+this option has no effect. The default value is
 .BR 100.
 .TP
 .BR \--heighttype " TYPE"
-Determine how height is calculated. Possible values for 
+Determine how height is calculated. Possible values for
 .I TYPE
-are 
+are
 .BR pixel,
 .BR request
 or
@@ -102,8 +103,8 @@ The default value is
 .BR pixel.
 .TP
 .BR \--height " NUM"
-Height of a panel. When 
-.BR --heigthtype=request 
+Height of a panel. When
+.BR --heigthtype=request
 this option has no effect. The default value is
 .BR 26.
 .TP
@@ -113,23 +114,23 @@ Identify panel window type as dock. The default value is
 .TP
 .BR \--SetPartialStrut " BOOL"
 Reserve panel's space so that it will not be covered by maximazied windows. The
-default value is 
+default value is
 .BR false.
 .TP
 .BR \--transparent " BOOL"
-Use transparency. Default value is 
-.BR false. 
+Use transparency. Default value is
+.BR false.
 .TP
 .BR \--tint " NUM"
-Color used to "tint" background wallpaper with. 
+Color used to "tint" background wallpaper with.
 .I NUM
 is 32bit width hexadecimal number.
-The default value is 
+The default value is
 .BR 0xFFFFFFFF.
 .TP
 .BR \--alpha " NUM"
 Percentage of transparency.
-.I NUM 
+.I NUM
 should be a value between 0 and 256. The default value is
 .BR 127.
 .TP
@@ -148,7 +149,7 @@ Define the monitor on which you like trayer to appear, number of zero to number
 of monitors minus one, or the string "primary" are valid. The default value is
 .BR 0.
 .SH EXAMPLES
-.LP 
+.LP
 Place trayer to the top right edge of the screen and prevent other fullsize
 windows to overlay it:
 .RS
@@ -172,7 +173,7 @@ code extraction from fbpanel
 .IP "Thomas Rydzynski"
 added new option 'distance'
 .IP "Keegan Carruthers-Smith <keegan.csmith@gmail.com>"
-fix align 
+fix align
 .IP "Yury Akudovich"
 added new option distancefrom option
 .IP "Jens Peter Secher <jps@debian.org>"

--- a/misc.c
+++ b/misc.c
@@ -411,7 +411,7 @@ get_net_wm_state(Window win, net_wm_state *nws)
             DBG("NET_WM_STATE_SKIP_PAGER ");
             nws->skip_pager = 1;
         } else if (state[num3] == a_NET_WM_STATE_SKIP_TASKBAR) {
-            DBG( "NET_WM_STATE_SKIP_TASKBAR ");	
+            DBG( "NET_WM_STATE_SKIP_TASKBAR ");
 	    nws->skip_taskbar = 1;
 	} else if (state[num3] == a_NET_WM_STATE_STICKY) {
             DBG( "NET_WM_STATE_STICKY ");
@@ -452,7 +452,7 @@ get_net_wm_window_type(Window win, net_wm_window_type *nwwt)
             DBG("NET_WM_WINDOW_TYPE_DESKTOP ");
             nwwt->desktop = 1;
         } else if (state[num3] == a_NET_WM_WINDOW_TYPE_DOCK) {
-            DBG( "NET_WM_WINDOW_TYPE_DOCK ");	
+            DBG( "NET_WM_WINDOW_TYPE_DOCK ");
 	    nwwt->dock = 1;
 	} else if (state[num3] == a_NET_WM_WINDOW_TYPE_TOOLBAR) {
             DBG( "NET_WM_WINDOW_TYPE_TOOLBAR ");
@@ -542,15 +542,15 @@ calculate_width(int scrw, int wtype, int allign, int margin,
 
 
 void
-calculate_position(panel *np, int distance,int distancefrom)
+calculate_position(panel *np, int *distance,int *distancefrom)
 {
-    int sswidth, ssheight, minx, miny, distancex, distancey;
+    int sswidth, ssheight, minx, miny, distancex=0, distancey=0, i;
     GdkScreen *screen;
     GdkDisplay *display;
     GdkRectangle *monitorGeometry;
 
     ENTER;
-    
+
     display = gdk_display_get_default ();
     screen  = gdk_display_get_default_screen(display);
 
@@ -562,22 +562,33 @@ calculate_position(panel *np, int distance,int distancefrom)
     }
 
     gdk_screen_get_monitor_geometry(screen,np->monitor,monitorGeometry);
-    
-    sswidth  = monitorGeometry->width; 
+
+    sswidth  = monitorGeometry->width;
     ssheight = monitorGeometry->height;
 
     minx = monitorGeometry->x;
     miny = monitorGeometry->y;
 
     free(monitorGeometry);
-    
-    if (distancefrom == DISTANCEFROM_TOP || distancefrom == DISTANCEFROM_BOTTOM) {
-        distancex = 0;
-        distancey = (distancefrom == DISTANCEFROM_TOP) ? distance : -distance;
-    } else {
-        distancex = (distancefrom == DISTANCEFROM_LEFT) ? distance : -distance;
-        distancey = 0;
+
+    for (i = 0; i < DISTANCE_MAX_ARRAY_SIZE; i++) {
+        switch (distancefrom[i]) {
+            case DISTANCEFROM_TOP:
+                distancey = distance[i];
+                break;
+            case DISTANCEFROM_BOTTOM:
+                distancey = -distance[i];
+                break;
+            case DISTANCEFROM_LEFT:
+                distancex = distance[i];
+                break;
+            case DISTANCEFROM_RIGHT:
+                distancex = -distance[i];
+                break;
+        }
     }
+
+    DBG("x value: %d\ty value: %d\n", distancex, distancey);
 
     if (np->edge == EDGE_TOP || np->edge == EDGE_BOTTOM) {
         np->aw = np->width;
@@ -686,10 +697,10 @@ gtk_image_new_from_file_scaled(const gchar *file, gint width,
     GtkWidget *img;
 
     ENTER;
-    if (g_file_test(file, G_FILE_TEST_EXISTS)) {		
+    if (g_file_test(file, G_FILE_TEST_EXISTS)) {
         GError *err = NULL;
         GdkPixbuf *pb;
-		
+
         pb = gdk_pixbuf_new_from_file(file, &err);
         if (err || !pb) {
             g_error_free(err);
@@ -698,9 +709,9 @@ gtk_image_new_from_file_scaled(const gchar *file, gint width,
 
             pb_scaled = gdk_pixbuf_scale_simple(pb, width, height,
                   GDK_INTERP_BILINEAR);
-		
-            img = gtk_image_new_from_pixbuf(pb_scaled);			
-		
+
+            img = gtk_image_new_from_pixbuf(pb_scaled);
+
             g_object_unref(pb);
             g_object_unref(pb_scaled);
 
@@ -737,7 +748,3 @@ get_button_spacing(GtkRequisition *req, GtkContainer *parent, gchar *name)
     gtk_widget_destroy(b);
     RET();
 }
-
-
-
-

--- a/misc.h
+++ b/misc.h
@@ -48,7 +48,7 @@ int get_wm_state (Window win);
 void get_net_wm_state(Window win, net_wm_state *nws);
 void get_net_wm_window_type(Window win, net_wm_window_type *nwwt);
 
-void calculate_position(panel *np, int distance,int distancefrom);
+void calculate_position(panel *np, int *distance,int *distancefrom);
 gchar *expand_tilda(gchar *file);
 GtkWidget *gtk_image_new_from_file_scaled(const gchar *file, gint width, gint height);
 void get_button_spacing(GtkRequisition *req, GtkContainer *parent, gchar *name);

--- a/panel.h
+++ b/panel.h
@@ -20,6 +20,7 @@ enum { POS_NONE, POS_START, POS_END };
 #define PANEL_HEIGHT_MAX      200
 #define PANEL_HEIGHT_MIN      2
 #define PANEL_WIDTH_DEFAULT   100
+#define DISTANCE_MAX_ARRAY_SIZE 2
 
 typedef struct {
 


### PR DESCRIPTION
Added the feature to define an offset from two edges. For example, `trayer --edge top --align right --distance 4,4 --distancefrom top,right --widthtype request --transparent true --height 24 --alpha 0 --tint 0x282c34 --padding 5 --monitor 0 --iconspacing 3` for the following systray.
![trayer](https://user-images.githubusercontent.com/50531499/110174948-3b4e8200-7e01-11eb-8307-fff6d1aff39f.jpg)
