### PR TITLE
fixes --alpha range (0-256 => 0-255) in documentation

### DIFF
--- a/README
+++ b/README
@@ -46,7 +46,7 @@ OPTIONS
                       maximazied windows <true|false>
 	--transparent   - use transparency <true|false>
 	--tint			    - color used to "tint" background wallpaper with
-	--alpha			    - percentage of transparency <0-256>
+	--alpha			    - percentage of transparency <0-255>
 	--expand		    - specifies if trayer can accomodate extra space 
                     or not <true|false>
 	--padding		    - extra space between trayer's window frame and docked icons

--- a/man/trayer.1
+++ b/man/trayer.1
@@ -131,7 +131,7 @@ The default value is
 .BR \--alpha " NUM"
 Percentage of transparency.
 .I NUM
-should be a value between 0 and 256. The default value is
+should be a value between 0 and 255. The default value is
 .BR 127.
 .TP
 .BR \--expand " BOOL"


### PR DESCRIPTION
When a value of `256` is entered into the `--alpha` option an error is thrown:

    gdk_pixbuf_composite_color_simple: assertion 'overall_alpha >= 0 && overall_alpha <= 255' failed